### PR TITLE
Feature/init db flyway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,13 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- opencsv -->
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>5.9</version>
+        </dependency>
 <!--        <dependency>-->
 <!--            <groupId>org.springframework.security</groupId>-->
 <!--            <artifactId>spring-security-test</artifactId>-->

--- a/src/main/java/com/example/wellueducationservice/controller/QuizController.java
+++ b/src/main/java/com/example/wellueducationservice/controller/QuizController.java
@@ -1,0 +1,31 @@
+package com.example.wellueducationservice.controller;
+
+import com.example.wellueducationservice.service.QuizApplicationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/quizzes")
+public class QuizController {
+
+    private final QuizApplicationService quizService;
+
+    public QuizController(QuizApplicationService quizService) {
+        this.quizService = quizService;
+    }
+
+    @PostMapping("/upload")
+    public ResponseEntity<String> uploadQuiz(
+            @RequestParam("title") String title,
+            @RequestParam("file") MultipartFile file
+    ) {
+
+        quizService.createQuizFromCsv(title, file);
+
+        return ResponseEntity.ok("Quiz created successfully");
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/dto/request/CsvQuestionRow.java
+++ b/src/main/java/com/example/wellueducationservice/dto/request/CsvQuestionRow.java
@@ -1,0 +1,10 @@
+package com.example.wellueducationservice.dto.request;
+
+public record CsvQuestionRow(
+        String question,
+        String correct,
+        String wrong1,
+        String wrong2,
+        String wrong3,
+        String explanation
+) {}

--- a/src/main/java/com/example/wellueducationservice/entity/Question.java
+++ b/src/main/java/com/example/wellueducationservice/entity/Question.java
@@ -14,11 +14,18 @@ public class Question {
 
     @Id
     @GeneratedValue
+    @Column(columnDefinition = "uuid")
     private UUID id;
 
     private String content;
 
     @ElementCollection
+    @CollectionTable(
+            name = "question_choices",
+            joinColumns = @JoinColumn(name = "question_id")
+    )
+    @Column(name = "choice_text")
+    @OrderColumn(name = "choice_order")
     private List<String> choices;
 
     private int correctAnswerIndex;

--- a/src/main/java/com/example/wellueducationservice/entity/Quiz.java
+++ b/src/main/java/com/example/wellueducationservice/entity/Quiz.java
@@ -19,6 +19,7 @@ public class Quiz {
 
     @Id
     @GeneratedValue
+    @Column(columnDefinition = "uuid")
     private UUID id;
 
     private String title;

--- a/src/main/java/com/example/wellueducationservice/entity/Quiz.java
+++ b/src/main/java/com/example/wellueducationservice/entity/Quiz.java
@@ -2,7 +2,9 @@ package com.example.wellueducationservice.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +13,8 @@ import java.util.UUID;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
+@Setter
+@Getter
 public class Quiz {
 
     @Id

--- a/src/main/java/com/example/wellueducationservice/repository/QuizRepository.java
+++ b/src/main/java/com/example/wellueducationservice/repository/QuizRepository.java
@@ -1,0 +1,11 @@
+package com.example.wellueducationservice.repository;
+
+import com.example.wellueducationservice.entity.Quiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface QuizRepository extends JpaRepository<Quiz, UUID> {
+}

--- a/src/main/java/com/example/wellueducationservice/service/CsvParserService.java
+++ b/src/main/java/com/example/wellueducationservice/service/CsvParserService.java
@@ -1,0 +1,62 @@
+package com.example.wellueducationservice.service;
+
+import com.example.wellueducationservice.dto.request.CsvQuestionRow;
+import com.opencsv.CSVReader;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class CsvParserService {
+
+    public List<CsvQuestionRow> parse(MultipartFile file) {
+        List<CsvQuestionRow> rows = new ArrayList<>();
+
+        try (CSVReader reader = new CSVReader(new InputStreamReader(file.getInputStream()))) {
+
+            String[] line;
+            boolean isFirstRow = true;
+            int rowNumber = 0;
+
+            while ((line = reader.readNext()) != null) {
+                rowNumber++;
+
+                if (isFirstRow) {
+                    isFirstRow = false;
+                    continue;
+                }
+
+                validate(line, rowNumber);
+
+                rows.add(new CsvQuestionRow(
+                        line[0].trim(),
+                        line[1].trim(),
+                        line[2].trim(),
+                        line[3].trim(),
+                        line[4].trim(),
+                        line[5].trim()
+                ));
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse CSV", e);
+        }
+
+        return rows;
+    }
+
+    private void validate(String[] line, int rowNumber) {
+        if (line.length != 6) {
+            throw new IllegalArgumentException("Invalid column count at row " + rowNumber);
+        }
+
+        for (int i = 0; i < line.length; i++) {
+            if (line[i] == null || line[i].isBlank()) {
+                throw new IllegalArgumentException("Empty value at row " + rowNumber + ", column " + i);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/service/QuestionCreationService.java
+++ b/src/main/java/com/example/wellueducationservice/service/QuestionCreationService.java
@@ -1,0 +1,60 @@
+package com.example.wellueducationservice.service;
+
+import com.example.wellueducationservice.dto.request.CsvQuestionRow;
+import com.example.wellueducationservice.entity.Question;
+import com.example.wellueducationservice.entity.Quiz;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class QuestionCreationService {
+
+    public Quiz createQuizFromRows(String title, List<CsvQuestionRow> rows) {
+
+        Quiz quiz = new Quiz();
+        quiz.setTitle(title);
+
+        List<Question> questions = new ArrayList<>();
+
+        for (CsvQuestionRow row : rows) {
+            Question question = mapToQuestion(row, quiz);
+            questions.add(question);
+        }
+
+        quiz.setQuestions(questions);
+
+        return quiz;
+    }
+
+    private Question mapToQuestion(CsvQuestionRow row, Quiz quiz) {
+
+        Question question = new Question();
+
+        question.setContent(row.question());
+
+        // Build choices (correct ALWAYS first)
+        List<String> choices = List.of(
+                row.correct(),
+                row.wrong1(),
+                row.wrong2(),
+                row.wrong3()
+        );
+
+        question.setChoices(choices);
+
+        // Enforce rule: correct answer index = 0
+        question.setCorrectAnswerIndex(0);
+
+        question.setExplanation(row.explanation());
+
+        // Optional: default points
+        question.setPoints(1);
+
+        // Set relationship
+        question.setQuiz(quiz);
+
+        return question;
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/service/QuizApplicationService.java
+++ b/src/main/java/com/example/wellueducationservice/service/QuizApplicationService.java
@@ -1,0 +1,39 @@
+package com.example.wellueducationservice.service;
+
+import com.example.wellueducationservice.dto.request.CsvQuestionRow;
+import com.example.wellueducationservice.entity.Quiz;
+import com.example.wellueducationservice.repository.QuizRepository;
+import org.hibernate.annotations.SecondaryRow;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+public class QuizApplicationService {
+    private final CsvParserService parserService;
+    private final QuizCreationService creationService;
+    private final QuizRepository quizRepository;
+
+    public QuizApplicationService(
+            CsvParserService parserService,
+            QuizCreationService creationService,
+            QuizRepository quizRepository
+    ) {
+        this.parserService = parserService;
+        this.creationService = creationService;
+        this.quizRepository = quizRepository;
+    }
+
+    public Quiz createQuizFromCsv(String title, MultipartFile file) {
+
+        // 1. Parse CSV
+        List<CsvQuestionRow> rows = parserService.parse(file);
+
+        // 2. Convert to entities
+        Quiz quiz = creationService.createQuizFromRows(title, rows);
+
+        // 3. Save ONCE (cascade handles questions)
+        return quizRepository.save(quiz);
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/service/QuizCreationService.java
+++ b/src/main/java/com/example/wellueducationservice/service/QuizCreationService.java
@@ -1,0 +1,59 @@
+package com.example.wellueducationservice.service;
+
+import com.example.wellueducationservice.dto.request.CsvQuestionRow;
+import com.example.wellueducationservice.entity.Question;
+import com.example.wellueducationservice.entity.Quiz;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class QuizCreationService {
+    public Quiz createQuizFromRows(String title, List<CsvQuestionRow> rows) {
+
+        Quiz quiz = new Quiz();
+        quiz.setTitle(title);
+
+        List<Question> questions = new ArrayList<>();
+
+        for (CsvQuestionRow row : rows) {
+            Question question = mapToQuestion(row, quiz);
+            questions.add(question);
+        }
+
+        quiz.setQuestions(questions);
+
+        return quiz;
+    }
+
+    private Question mapToQuestion(CsvQuestionRow row, Quiz quiz) {
+
+        Question question = new Question();
+
+        question.setContent(row.question());
+
+        // Build choices (correct ALWAYS first)
+        List<String> choices = List.of(
+                row.correct(),
+                row.wrong1(),
+                row.wrong2(),
+                row.wrong3()
+        );
+
+        question.setChoices(choices);
+
+        // Enforce rule: correct answer index = 0
+        question.setCorrectAnswerIndex(0);
+
+        question.setExplanation(row.explanation());
+
+        // Optional: default points
+        question.setPoints(1);
+
+        // Set relationship
+        question.setQuiz(quiz);
+
+        return question;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,11 @@ server.port=8083
 spring.datasource.url=jdbc:postgresql://education-db:5432/education
 spring.datasource.username=education
 spring.datasource.password=password
+
+jpa:
+hibernate:
+ddl-auto: validate   # VERY important
+
+flyway:
+enabled: true
+locations: classpath:db/migration

--- a/src/main/resources/db/migration/V2__quiz_question.sql
+++ b/src/main/resources/db/migration/V2__quiz_question.sql
@@ -1,0 +1,75 @@
+-- Enable UUID generation
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- =========================
+-- QUIZZES TABLE
+-- =========================
+CREATE TABLE quizzes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    title TEXT NOT NULL,
+    difficulty TEXT NOT NULL,
+
+    time_limit INTEGER,
+    is_daily BOOLEAN DEFAULT FALSE,
+    total_points INTEGER
+);
+
+-- Difficulty constraint
+ALTER TABLE quizzes
+ADD CONSTRAINT chk_quiz_difficulty
+CHECK (difficulty IN ('EASY', 'MEDIUM', 'HARD'));
+
+-- Time limit must be positive
+ALTER TABLE quizzes
+ADD CONSTRAINT chk_time_limit_positive
+CHECK (time_limit IS NULL OR time_limit > 0);
+
+
+-- =========================
+-- QUESTIONS TABLE
+-- =========================
+CREATE TABLE questions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    quiz_id UUID NOT NULL,
+
+    content TEXT NOT NULL,
+    correct_answer_index INTEGER NOT NULL,
+    explanation TEXT,
+    points INTEGER,
+
+    CONSTRAINT fk_questions_quiz
+        FOREIGN KEY (quiz_id)
+        REFERENCES quizzes(id)
+        ON DELETE CASCADE
+);
+
+-- Points must be non-negative
+ALTER TABLE questions
+ADD CONSTRAINT chk_points_positive
+CHECK (points IS NULL OR points >= 0);
+
+
+-- =========================
+-- QUESTION_CHOICES TABLE
+-- =========================
+CREATE TABLE question_choices (
+    id BIGSERIAL PRIMARY KEY,
+
+    question_id UUID NOT NULL,
+    choice_text TEXT NOT NULL,
+    choice_order INTEGER NOT NULL,
+
+    CONSTRAINT fk_choices_question
+        FOREIGN KEY (question_id)
+        REFERENCES questions(id)
+        ON DELETE CASCADE
+);
+
+
+-- =========================
+-- INDEXES
+-- =========================
+CREATE INDEX idx_questions_quiz_id ON questions(quiz_id);
+CREATE INDEX idx_choices_question_id ON question_choices(question_id);


### PR DESCRIPTION
## What this PR does
- Adds Flyway migration `V1__init.sql`
- Initializes database schema for:
  - quizzes
  - questions
  - question_choices

## Database Design
- UUID primary keys using `gen_random_uuid()`
- One-to-many relationship:
  - quizzes → questions
- ElementCollection mapping:
  - questions → choices (stored in separate table)
- Foreign keys with `ON DELETE CASCADE`
- Indexes added for performance

## Changes in Entities
- Configured `@ElementCollection` with:
  - @CollectionTable (question_choices)
  - @OrderColumn (choice_order)
- Ensured compatibility with Flyway schema

## How to test
1. Run:

closes #4