### PR TITLE
Feature/9 refactor quiz setup

### DIFF
--- a/src/main/java/com/example/wellueducationservice/controller/QuizAttemptController.java
+++ b/src/main/java/com/example/wellueducationservice/controller/QuizAttemptController.java
@@ -1,0 +1,52 @@
+package com.example.wellueducationservice.controller;
+
+import com.example.wellueducationservice.dto.request.QuizAttemptStartRequestDto;
+import com.example.wellueducationservice.dto.request.QuizAttemptSubmitRequestDto;
+import com.example.wellueducationservice.dto.response.QuizAttemptResponseDto;
+import com.example.wellueducationservice.dto.response.QuizAttemptResultResponseDto;
+import com.example.wellueducationservice.service.QuizAttemptService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/quiz-attempts")
+public class QuizAttemptController {
+
+    private final QuizAttemptService quizAttemptService;
+
+    public QuizAttemptController(QuizAttemptService quizAttemptService) {
+        this.quizAttemptService = quizAttemptService;
+    }
+
+    @PostMapping("/start")
+    public ResponseEntity<QuizAttemptResponseDto> startAttempt(@RequestBody QuizAttemptStartRequestDto request) {
+        QuizAttemptResponseDto response = quizAttemptService.startAttempt(request);
+
+        return ResponseEntity.status(201).body(response);
+    }
+
+    @PostMapping("/{attemptId}/submit")
+    public ResponseEntity<QuizAttemptResultResponseDto> submitAttempt(
+            @PathVariable UUID attemptId,
+            @RequestBody QuizAttemptSubmitRequestDto request
+    ) {
+        QuizAttemptResultResponseDto response = quizAttemptService.submitAttempt(attemptId, request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<List<QuizAttemptResponseDto>> getUserAttempts(@PathVariable UUID userId) {
+        List<QuizAttemptResponseDto> response = quizAttemptService.getUserAttempts(userId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/controller/QuizController.java
+++ b/src/main/java/com/example/wellueducationservice/controller/QuizController.java
@@ -1,8 +1,12 @@
 package com.example.wellueducationservice.controller;
 
+import com.example.wellueducationservice.dto.request.CreateQuizRequestDto;
+import com.example.wellueducationservice.dto.response.QuestionImportResponseDto;
+import com.example.wellueducationservice.dto.response.QuizResponseDto;
 import com.example.wellueducationservice.service.QuizApplicationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,13 +23,18 @@ public class QuizController {
     }
 
     @PostMapping("/upload")
-    public ResponseEntity<String> uploadQuiz(
-            @RequestParam("title") String title,
+    public ResponseEntity<QuestionImportResponseDto> uploadQuestions(
             @RequestParam("file") MultipartFile file
     ) {
+        QuestionImportResponseDto response = quizService.importQuestions(file);
 
-        quizService.createQuizFromCsv(title, file);
+        return ResponseEntity.status(201).body(response);
+    }
 
-        return ResponseEntity.ok("Quiz created successfully");
+    @PostMapping
+    public ResponseEntity<QuizResponseDto> createQuiz(@RequestBody CreateQuizRequestDto request) {
+        QuizResponseDto response = quizService.createQuiz(request);
+
+        return ResponseEntity.status(201).body(response);
     }
 }

--- a/src/main/java/com/example/wellueducationservice/dto/request/CreateQuizRequestDto.java
+++ b/src/main/java/com/example/wellueducationservice/dto/request/CreateQuizRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.wellueducationservice.dto.request;
+
+import com.example.wellueducationservice.enumeration.Difficulty;
+
+public record CreateQuizRequestDto(
+        String title,
+        Difficulty difficulty,
+        Integer timeLimit,
+        Boolean isDaily,
+        Integer questionCount
+) {
+}

--- a/src/main/java/com/example/wellueducationservice/dto/response/QuestionImportResponseDto.java
+++ b/src/main/java/com/example/wellueducationservice/dto/response/QuestionImportResponseDto.java
@@ -1,0 +1,7 @@
+package com.example.wellueducationservice.dto.response;
+
+public record QuestionImportResponseDto(
+        int importedCount,
+        long availableQuestionCount
+) {
+}

--- a/src/main/java/com/example/wellueducationservice/dto/response/QuizAttemptQuestionResultDto.java
+++ b/src/main/java/com/example/wellueducationservice/dto/response/QuizAttemptQuestionResultDto.java
@@ -1,0 +1,16 @@
+package com.example.wellueducationservice.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+public record QuizAttemptQuestionResultDto(
+        UUID questionId,
+        String content,
+        List<String> choices,
+        Integer selectedAnswerIndex,
+        Integer correctAnswerIndex,
+        boolean correct,
+        String explanation,
+        Integer points
+) {
+}

--- a/src/main/java/com/example/wellueducationservice/dto/response/QuizAttemptResultResponseDto.java
+++ b/src/main/java/com/example/wellueducationservice/dto/response/QuizAttemptResultResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.wellueducationservice.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record QuizAttemptResultResponseDto(
+        UUID attemptId,
+        UUID userId,
+        Double score,
+        LocalDateTime completedAt,
+        QuizResponseDto quiz,
+        List<QuizAttemptQuestionResultDto> questionResults
+) {
+}

--- a/src/main/java/com/example/wellueducationservice/entity/QuizAttempt.java
+++ b/src/main/java/com/example/wellueducationservice/entity/QuizAttempt.java
@@ -3,7 +3,6 @@ package com.example.wellueducationservice.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
@@ -43,8 +42,8 @@ public class QuizAttempt {
         for (Question q : quiz.getQuestions()) {
             Integer userAnswer = answers.get(q.getId());
 
-            if (userAnswer== q.getCorrectAnswerIndex()) {
-                total += q.getPoints();
+            if (userAnswer != null && userAnswer == q.getCorrectAnswerIndex()) {
+                total += q.getPoints() == null ? 0 : q.getPoints();
             }
         }
 

--- a/src/main/java/com/example/wellueducationservice/repository/QuestionRepository.java
+++ b/src/main/java/com/example/wellueducationservice/repository/QuestionRepository.java
@@ -3,7 +3,13 @@ package com.example.wellueducationservice.repository;
 import com.example.wellueducationservice.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface QuestionRepository extends JpaRepository<Question, UUID> {
+    List<Question> findAllByQuizIsNull();
+
+    List<Question> findAllByQuizIsNullOrderByContentAsc();
+
+    long countByQuizIsNull();
 }

--- a/src/main/java/com/example/wellueducationservice/repository/QuizRepository.java
+++ b/src/main/java/com/example/wellueducationservice/repository/QuizRepository.java
@@ -1,20 +1,14 @@
 package com.example.wellueducationservice.repository;
 
-import com.example.wellueducationservice.enumeration.Difficulty;
 import com.example.wellueducationservice.entity.Quiz;
+import com.example.wellueducationservice.enumeration.Difficulty;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface QuizRepository extends JpaRepository<Quiz, UUID>{
-    List<Quiz> findByDifficulty(Difficulty difficulty);
-import com.example.wellueducationservice.entity.Quiz;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-import java.util.UUID;
-
 @Repository
 public interface QuizRepository extends JpaRepository<Quiz, UUID> {
+    List<Quiz> findByDifficulty(Difficulty difficulty);
 }

--- a/src/main/java/com/example/wellueducationservice/service/QuizApplicationService.java
+++ b/src/main/java/com/example/wellueducationservice/service/QuizApplicationService.java
@@ -1,39 +1,135 @@
 package com.example.wellueducationservice.service;
 
+import com.example.wellueducationservice.dto.request.CreateQuizRequestDto;
 import com.example.wellueducationservice.dto.request.CsvQuestionRow;
+import com.example.wellueducationservice.dto.response.QuestionImportResponseDto;
+import com.example.wellueducationservice.dto.response.QuizResponseDto;
+import com.example.wellueducationservice.entity.Question;
 import com.example.wellueducationservice.entity.Quiz;
+import com.example.wellueducationservice.mapper.QuizMapper;
+import com.example.wellueducationservice.repository.QuestionRepository;
 import com.example.wellueducationservice.repository.QuizRepository;
-import org.hibernate.annotations.SecondaryRow;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 @Service
 public class QuizApplicationService {
     private final CsvParserService parserService;
     private final QuizCreationService creationService;
+    private final QuestionRepository questionRepository;
     private final QuizRepository quizRepository;
+    private final QuizMapper quizMapper;
 
     public QuizApplicationService(
             CsvParserService parserService,
             QuizCreationService creationService,
-            QuizRepository quizRepository
+            QuestionRepository questionRepository,
+            QuizRepository quizRepository,
+            QuizMapper quizMapper
     ) {
         this.parserService = parserService;
         this.creationService = creationService;
+        this.questionRepository = questionRepository;
         this.quizRepository = quizRepository;
+        this.quizMapper = quizMapper;
     }
 
-    public Quiz createQuizFromCsv(String title, MultipartFile file) {
-
-        // 1. Parse CSV
+    @Transactional
+    public QuestionImportResponseDto importQuestions(MultipartFile file) {
         List<CsvQuestionRow> rows = parserService.parse(file);
+        List<Question> questions = creationService.createUnassignedQuestions(rows);
 
-        // 2. Convert to entities
-        Quiz quiz = creationService.createQuizFromRows(title, rows);
+        questionRepository.saveAll(questions);
 
-        // 3. Save ONCE (cascade handles questions)
-        return quizRepository.save(quiz);
+        return new QuestionImportResponseDto(questions.size(), questionRepository.countByQuizIsNull());
+    }
+
+    @Transactional
+    public QuizResponseDto createQuiz(CreateQuizRequestDto request) {
+        validateCreateQuizRequest(request);
+
+        List<Question> availableQuestions = new ArrayList<>(questionRepository.findAllByQuizIsNullOrderByContentAsc());
+        if (availableQuestions.size() < request.questionCount()) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Not enough unassigned questions to create the requested quiz"
+            );
+        }
+
+        List<Question> selectedQuestions = selectUniqueQuestions(availableQuestions, request.questionCount());
+        if (selectedQuestions.size() < request.questionCount()) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Not enough unique unassigned questions to create the requested quiz"
+            );
+        }
+
+        int totalPoints = selectedQuestions.stream()
+                .map(Question::getPoints)
+                .map(points -> points == null ? 0 : points)
+                .reduce(0, Integer::sum);
+
+        Quiz quiz = creationService.createQuiz(request, totalPoints);
+        Quiz savedQuiz = quizRepository.save(quiz);
+
+        for (Question question : selectedQuestions) {
+            question.setDifficulty(savedQuiz.getDifficulty());
+            savedQuiz.addQuestion(question);
+        }
+
+        questionRepository.saveAll(selectedQuestions);
+
+        return quizMapper.toDto(savedQuiz);
+    }
+
+    private void validateCreateQuizRequest(CreateQuizRequestDto request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Quiz request body is required");
+        }
+
+        if (request.title() == null || request.title().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Quiz title is required");
+        }
+
+        if (request.questionCount() == null || request.questionCount() <= 0) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Quiz questionCount must be greater than zero"
+            );
+        }
+    }
+
+    private List<Question> selectUniqueQuestions(List<Question> availableQuestions, int questionCount) {
+        List<Question> selectedQuestions = new ArrayList<>();
+        Set<String> seenContents = new HashSet<>();
+
+        for (Question question : availableQuestions) {
+            String normalizedContent = normalizeQuestionContent(question.getContent());
+            if (!seenContents.add(normalizedContent)) {
+                continue;
+            }
+
+            selectedQuestions.add(question);
+            if (selectedQuestions.size() == questionCount) {
+                break;
+            }
+        }
+
+        return selectedQuestions;
+    }
+
+    private String normalizeQuestionContent(String content) {
+        return content == null
+                ? ""
+                : content.trim().replaceAll("\\s+", " ").toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/com/example/wellueducationservice/service/QuizAttemptService.java
+++ b/src/main/java/com/example/wellueducationservice/service/QuizAttemptService.java
@@ -3,18 +3,27 @@ package com.example.wellueducationservice.service;
 import com.example.wellueducationservice.dto.request.QuizAttemptStartRequestDto;
 import com.example.wellueducationservice.dto.request.QuizAttemptSubmitRequestDto;
 import com.example.wellueducationservice.dto.response.QuizAttemptResponseDto;
+import com.example.wellueducationservice.dto.response.QuizAttemptQuestionResultDto;
+import com.example.wellueducationservice.dto.response.QuizAttemptResultResponseDto;
 import com.example.wellueducationservice.entity.Quiz;
 import com.example.wellueducationservice.entity.QuizAttempt;
+import com.example.wellueducationservice.entity.Question;
 import com.example.wellueducationservice.mapper.QuizAttemptMapper;
+import com.example.wellueducationservice.mapper.QuizMapper;
 import com.example.wellueducationservice.repository.QuizAttemptRepository;
 import com.example.wellueducationservice.repository.QuizRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.UUID;
 
@@ -24,47 +33,147 @@ public class QuizAttemptService {
     private final QuizRepository quizRepository;
     private final QuizAttemptRepository quizAttemptRepository;
     private final QuizAttemptMapper quizAttemptMapper;
+    private final QuizMapper quizMapper;
 
 
-    public ResponseEntity<QuizAttemptResponseDto> startAttempt(QuizAttemptStartRequestDto request) {
-        List<Quiz> quizzes = quizRepository.findByDifficulty(request.difficulty());
+    @Transactional
+    public QuizAttemptResponseDto startAttempt(QuizAttemptStartRequestDto request) {
+        validateStartRequest(request);
+
+        List<Quiz> quizzes = quizRepository.findByDifficulty(request.difficulty()).stream()
+                .filter(quiz -> quiz.getQuestions() != null && !quiz.getQuestions().isEmpty())
+                .toList();
 
         if (quizzes.isEmpty()) {
-            return ResponseEntity.notFound().build();
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No quizzes available for this difficulty");
         }
-
         Quiz quiz = quizzes.get(ThreadLocalRandom.current().nextInt(quizzes.size()));
-
         QuizAttempt savedAttempt = quizAttemptRepository.save(quizAttemptMapper.toEntity(request, quiz));
-        return ResponseEntity.status(HttpStatus.CREATED).body(quizAttemptMapper.toDto(savedAttempt));
+
+        return quizAttemptMapper.toDto(savedAttempt);
     }
 
-    public ResponseEntity<QuizAttemptResponseDto> submitAttempt(UUID attemptId, QuizAttemptSubmitRequestDto request) {
+    @Transactional
+    public QuizAttemptResultResponseDto submitAttempt(UUID attemptId, QuizAttemptSubmitRequestDto request) {
+        validateSubmitRequest(request);
 
         QuizAttempt attempt = quizAttemptRepository.findById(attemptId)
-                .orElse(null);
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Attempt not found"));
 
-        if (attempt == null) {
-            return ResponseEntity.notFound().build();
+        if (attempt.getCompletedAt() != null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Attempt has already been submitted");
         }
 
+        validateSubmittedAnswers(attempt.getQuiz(), request.answers());
         quizAttemptMapper.updateAnswers(request.answers(), attempt);
 
         attempt.calculateScore();
-
         attempt.setCompletedAt(LocalDateTime.now());
 
         QuizAttempt savedAttempt = quizAttemptRepository.save(attempt);
+        List<QuizAttemptQuestionResultDto> questionResults = buildQuestionResults(savedAttempt);
 
-        return ResponseEntity.ok(quizAttemptMapper.toDto(savedAttempt));
+        return new QuizAttemptResultResponseDto(
+                savedAttempt.getAttemptId(),
+                savedAttempt.getUserId(),
+                savedAttempt.getScore(),
+                savedAttempt.getCompletedAt(),
+                quizMapper.toDto(savedAttempt.getQuiz()),
+                questionResults
+        );
     }
 
-    public ResponseEntity<List<QuizAttemptResponseDto>> getUserAttempts(UUID userId) {
-        List<QuizAttemptResponseDto> attempts = quizAttemptRepository.findByUserId(userId).stream()
+    @Transactional(readOnly = true)
+    public List<QuizAttemptResponseDto> getUserAttempts(UUID userId) {
+        if (userId == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "userId is required");
+        }
+
+        return quizAttemptRepository.findByUserId(userId).stream()
                 .map(quizAttemptMapper::toDto)
                 .toList();
-
-        return ResponseEntity.ok(attempts);
     }
 
+    private void validateStartRequest(QuizAttemptStartRequestDto request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Attempt start request is required");
+        }
+
+        if (request.userId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "userId is required");
+        }
+
+        if (request.difficulty() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "difficulty is required");
+        }
+    }
+
+    private void validateSubmitRequest(QuizAttemptSubmitRequestDto request) {
+        if (request == null || request.answers() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "answers are required");
+        }
+    }
+
+    private void validateSubmittedAnswers(Quiz quiz, Map<UUID, Integer> answers) {
+        Set<UUID> quizQuestionIds = new HashSet<>();
+        for (Question question : quiz.getQuestions()) {
+            quizQuestionIds.add(question.getId());
+        }
+
+        for (Map.Entry<UUID, Integer> answer : answers.entrySet()) {
+            UUID questionId = answer.getKey();
+            Integer selectedAnswerIndex = answer.getValue();
+
+            if (!quizQuestionIds.contains(questionId)) {
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        "Submitted answer contains a question that does not belong to this quiz"
+                );
+            }
+
+            Question quizQuestion = quiz.getQuestions().stream()
+                    .filter(question -> question.getId().equals(questionId))
+                    .findFirst()
+                    .orElseThrow(() -> new ResponseStatusException(
+                            HttpStatus.BAD_REQUEST,
+                            "Submitted answer references an unknown quiz question"
+                    ));
+
+            if (selectedAnswerIndex == null) {
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        "selectedAnswerIndex cannot be null"
+                );
+            }
+
+            if (selectedAnswerIndex < 0 || selectedAnswerIndex >= quizQuestion.getChoices().size()) {
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        "selectedAnswerIndex is out of range for one or more questions"
+                );
+            }
+        }
+    }
+
+    private List<QuizAttemptQuestionResultDto> buildQuestionResults(QuizAttempt attempt) {
+        List<QuizAttemptQuestionResultDto> questionResults = new ArrayList<>();
+
+        for (Question question : attempt.getQuiz().getQuestions()) {
+            Integer selectedAnswerIndex = attempt.getAnswers().get(question.getId());
+            boolean correct = selectedAnswerIndex != null && selectedAnswerIndex == question.getCorrectAnswerIndex();
+
+            questionResults.add(new QuizAttemptQuestionResultDto(
+                    question.getId(),
+                    question.getContent(),
+                    question.getChoices(),
+                    selectedAnswerIndex,
+                    question.getCorrectAnswerIndex(),
+                    correct,
+                    question.getExplanation(),
+                    question.getPoints()
+            ));
+        }
+
+        return questionResults;
+    }
 }

--- a/src/main/java/com/example/wellueducationservice/service/QuizCreationService.java
+++ b/src/main/java/com/example/wellueducationservice/service/QuizCreationService.java
@@ -1,8 +1,10 @@
 package com.example.wellueducationservice.service;
 
+import com.example.wellueducationservice.dto.request.CreateQuizRequestDto;
 import com.example.wellueducationservice.dto.request.CsvQuestionRow;
 import com.example.wellueducationservice.entity.Question;
 import com.example.wellueducationservice.entity.Quiz;
+import com.example.wellueducationservice.enumeration.Difficulty;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -10,31 +12,30 @@ import java.util.List;
 
 @Service
 public class QuizCreationService {
-    public Quiz createQuizFromRows(String title, List<CsvQuestionRow> rows) {
-
-        Quiz quiz = new Quiz();
-        quiz.setTitle(title);
-
+    public List<Question> createUnassignedQuestions(List<CsvQuestionRow> rows) {
         List<Question> questions = new ArrayList<>();
 
         for (CsvQuestionRow row : rows) {
-            Question question = mapToQuestion(row, quiz);
-            questions.add(question);
+            questions.add(mapToQuestion(row));
         }
 
-        quiz.setQuestions(questions);
-        quiz.setDifficulty("EASY");
-        quiz.setIsDaily(true);
-        quiz.setTimeLimit(100);
-        quiz.setTotalPoints(10);
+        return questions;
+    }
+
+    public Quiz createQuiz(CreateQuizRequestDto request, int totalPoints) {
+        Quiz quiz = new Quiz();
+        quiz.setTitle(request.title().trim());
+        quiz.setDifficulty(request.difficulty() == null ? Difficulty.EASY : request.difficulty());
+        quiz.setTimeLimit(request.timeLimit());
+        quiz.setIsDaily(request.isDaily() != null && request.isDaily());
+        quiz.setTotalPoints(totalPoints);
+        quiz.setQuestions(new ArrayList<>());
 
         return quiz;
     }
 
-    private Question mapToQuestion(CsvQuestionRow row, Quiz quiz) {
-
+    private Question mapToQuestion(CsvQuestionRow row) {
         Question question = new Question();
-
         question.setContent(row.question());
 
         // Build choices (correct ALWAYS first)
@@ -54,9 +55,7 @@ public class QuizCreationService {
 
         // Optional: default points
         question.setPoints(1);
-
-        // Set relationship
-        question.setQuiz(quiz);
+        question.setDifficulty(null);
 
         return question;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,10 +5,6 @@ spring.datasource.url=jdbc:postgresql://education-db:5432/education
 spring.datasource.username=education
 spring.datasource.password=password
 
-jpa:
-hibernate:
-ddl-auto: validate   # VERY important
-
-flyway:
-enabled: true
-locations: classpath:db/migration
+spring.jpa.hibernate.ddl-auto=validate
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration

--- a/src/main/resources/db/migration/V3__question_pool_support.sql
+++ b/src/main/resources/db/migration/V3__question_pool_support.sql
@@ -1,0 +1,9 @@
+ALTER TABLE questions
+ALTER COLUMN quiz_id DROP NOT NULL;
+
+ALTER TABLE questions
+ADD COLUMN difficulty TEXT;
+
+ALTER TABLE questions
+ADD CONSTRAINT chk_question_difficulty
+CHECK (difficulty IS NULL OR difficulty IN ('EASY', 'MEDIUM', 'HARD'));

--- a/src/main/resources/db/migration/V4__quiz_attempt.sql
+++ b/src/main/resources/db/migration/V4__quiz_attempt.sql
@@ -1,0 +1,27 @@
+CREATE TABLE quiz_attempt (
+    attempt_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    score DOUBLE PRECISION,
+    completed_at TIMESTAMP,
+    quiz_id UUID NOT NULL,
+
+    CONSTRAINT fk_quiz_attempt_quiz
+        FOREIGN KEY (quiz_id)
+        REFERENCES quizzes(id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE attempt_answers (
+    quiz_attempt_attempt_id UUID NOT NULL,
+    question_id UUID NOT NULL,
+    selected_answer INTEGER,
+
+    CONSTRAINT fk_attempt_answers_attempt
+        FOREIGN KEY (quiz_attempt_attempt_id)
+        REFERENCES quiz_attempt(attempt_id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_quiz_attempt_quiz_id ON quiz_attempt(quiz_id);
+CREATE INDEX idx_quiz_attempt_user_id ON quiz_attempt(user_id);
+CREATE INDEX idx_attempt_answers_attempt_id ON attempt_answers(quiz_attempt_attempt_id);


### PR DESCRIPTION
This PR completes the current education-service quiz flow in two areas:

1- quiz setup from imported questions
2- quiz attempt lifecycle for users
Questions are now imported from CSV into the database as unassigned records, and quizzes are created by selecting unused questions from that pool. Users can then start a random quiz by difficulty, submit answers, and receive a scored result with per-question review details.

Note
Duplicate questions are currently allowed in the database by design. The service only prevents duplicate question text from appearing within the same generated quiz. This keeps question import simple while still avoiding repeated questions in a single user quiz.