### PR TITLE
Feature/daily facts setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,17 @@
         <lombok.version>1.18.30</lombok.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>2023.0.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,6 +62,11 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/example/wellueducationservice/WelluEducationServiceApplication.java
+++ b/src/main/java/com/example/wellueducationservice/WelluEducationServiceApplication.java
@@ -2,8 +2,12 @@ package com.example.wellueducationservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableFeignClients
+@EnableScheduling
 public class WelluEducationServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/wellueducationservice/client/AiServiceClient.java
+++ b/src/main/java/com/example/wellueducationservice/client/AiServiceClient.java
@@ -1,0 +1,17 @@
+package com.example.wellueducationservice.client;
+
+import com.example.wellueducationservice.config.FeignConfig;
+import com.example.wellueducationservice.dto.response.AiFactResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(
+        name  = "ai-service",
+        url   = "${ai-service.base-url}",
+        configuration = FeignConfig.class
+)
+public interface AiServiceClient {
+
+    @PostMapping("/generate-daily-fact")
+    AiFactResponse generateDailyFact();
+}

--- a/src/main/java/com/example/wellueducationservice/client/AiServiceErrorDecoder.java
+++ b/src/main/java/com/example/wellueducationservice/client/AiServiceErrorDecoder.java
@@ -1,0 +1,27 @@
+package com.example.wellueducationservice.client;
+
+import com.example.wellueducationservice.exception.AiServiceException;
+import feign.Response;
+import feign.RetryableException;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AiServiceErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder defaultDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        String message = "AI Service error [%s]: HTTP %d".formatted(methodKey, response.status());
+        log.error(message);
+
+        return switch (response.status()) {
+            case 408, 503, 504 -> new RetryableException(
+                    response.status(), message, response.request().httpMethod(),
+                    (Long) null, response.request()
+            );
+            default -> new AiServiceException(message);
+        };
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/config/FeignConfig.java
+++ b/src/main/java/com/example/wellueducationservice/config/FeignConfig.java
@@ -20,8 +20,8 @@ public class FeignConfig {
     @Bean
     public Request.Options requestOptions() {
         return new Request.Options(
-                5,  TimeUnit.SECONDS,   // connect timeout
-                10, TimeUnit.SECONDS,   // read timeout
+                5,  TimeUnit.MINUTES,   // connect timeout
+                10, TimeUnit.MINUTES,   // read timeout
                 true                    // follow redirects
         );
     }

--- a/src/main/java/com/example/wellueducationservice/config/FeignConfig.java
+++ b/src/main/java/com/example/wellueducationservice/config/FeignConfig.java
@@ -1,0 +1,34 @@
+package com.example.wellueducationservice.config;
+
+import com.example.wellueducationservice.client.AiServiceErrorDecoder;
+import feign.Request;
+import feign.Retryer;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new AiServiceErrorDecoder();
+    }
+
+    @Bean
+    public Request.Options requestOptions() {
+        return new Request.Options(
+                5,  TimeUnit.SECONDS,   // connect timeout
+                10, TimeUnit.SECONDS,   // read timeout
+                true                    // follow redirects
+        );
+    }
+
+    @Bean
+    public Retryer retryer() {
+        // 3 attempts: initial 500ms, max 2s between retries
+        return new Retryer.Default(500, 2_000, 3);
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/config/SecurityConfig.java
+++ b/src/main/java/com/example/wellueducationservice/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.example.wellueducationservice.config.security;
+package com.example.wellueducationservice.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/example/wellueducationservice/controller/DailyFactController.java
+++ b/src/main/java/com/example/wellueducationservice/controller/DailyFactController.java
@@ -1,0 +1,29 @@
+package com.example.wellueducationservice.controller;
+
+import com.example.wellueducationservice.dto.response.DailyFactDto;
+import com.example.wellueducationservice.service.DailyFactService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/daily-facts")
+@RequiredArgsConstructor
+public class DailyFactController {
+
+    private final DailyFactService dailyFactService;
+
+    /**
+     * GET /api/v1/daily-facts/today
+     * Returns today's fact (from DB or freshly generated).
+     */
+    @GetMapping("/today")
+    public ResponseEntity<DailyFactDto> getTodayFact() {
+        DailyFactDto fact = dailyFactService.getTodayFact();
+        return ResponseEntity.ok(fact);
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/dto/response/AiFactResponse.java
+++ b/src/main/java/com/example/wellueducationservice/dto/response/AiFactResponse.java
@@ -1,0 +1,23 @@
+package com.example.wellueducationservice.dto.response;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+
+public record AiFactResponse (
+        @JsonProperty("date")
+         LocalDate date,
+
+        @JsonProperty("content")
+        String content,
+
+        @JsonProperty("category")
+        String category
+){}
+

--- a/src/main/java/com/example/wellueducationservice/dto/response/DailyFactDto.java
+++ b/src/main/java/com/example/wellueducationservice/dto/response/DailyFactDto.java
@@ -1,0 +1,35 @@
+package com.example.wellueducationservice.dto.response;
+
+
+import com.example.wellueducationservice.entity.DailyFact;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyFactDto {
+
+    private UUID id;
+    private String content;
+    private String category;
+    private LocalDate factDate;
+    private LocalDateTime createdAt;
+
+    public static DailyFactDto from(DailyFact fact) {
+        return DailyFactDto.builder()
+                .id(fact.getId())
+                .content(fact.getContent())
+                .category(fact.getCategory())
+                .factDate(fact.getFactDate())
+                .createdAt(fact.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/entity/DailyFact.java
+++ b/src/main/java/com/example/wellueducationservice/entity/DailyFact.java
@@ -1,0 +1,34 @@
+package com.example.wellueducationservice.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Setter
+@Getter
+public class DailyFact {
+    @Id
+    @GeneratedValue
+    @Column(columnDefinition = "uuid")
+    private UUID id;
+
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private String category;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+
+}

--- a/src/main/java/com/example/wellueducationservice/entity/DailyFact.java
+++ b/src/main/java/com/example/wellueducationservice/entity/DailyFact.java
@@ -1,13 +1,11 @@
 package com.example.wellueducationservice.entity;
 
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -29,6 +27,15 @@ public class DailyFact {
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDate factDate;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) createdAt = LocalDateTime.now();
+        if (factDate == null) factDate = createdAt.toLocalDate();
+    }
 
 
 }

--- a/src/main/java/com/example/wellueducationservice/exception/AiServiceException.java
+++ b/src/main/java/com/example/wellueducationservice/exception/AiServiceException.java
@@ -1,0 +1,6 @@
+package com.example.wellueducationservice.exception;
+
+public class AiServiceException extends RuntimeException {
+    public AiServiceException(String message) { super(message); }
+    public AiServiceException(String message, Throwable cause) { super(message, cause); }
+}

--- a/src/main/java/com/example/wellueducationservice/exception/FactNotFoundException.java
+++ b/src/main/java/com/example/wellueducationservice/exception/FactNotFoundException.java
@@ -1,0 +1,5 @@
+package com.example.wellueducationservice.exception;
+
+public class FactNotFoundException extends RuntimeException {
+    public FactNotFoundException(String message) { super(message); }
+}

--- a/src/main/java/com/example/wellueducationservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/wellueducationservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.example.wellueducationservice.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+// exception/GlobalExceptionHandler.java
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AiServiceException.class)
+    public ResponseEntity<Map<String, String>> handleAiServiceException(AiServiceException ex) {
+        log.error("AI Service error: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(Map.of(
+                        "error",   "AI service is currently unavailable.",
+                        "message", ex.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(FactNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleFactNotFound(FactNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGeneral(Exception ex) {
+        log.error("Unexpected error", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", "An unexpected error occurred."));
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/repository/DailyFactRepository.java
+++ b/src/main/java/com/example/wellueducationservice/repository/DailyFactRepository.java
@@ -1,0 +1,17 @@
+package com.example.wellueducationservice.repository;
+
+import com.example.wellueducationservice.entity.DailyFact;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface DailyFactRepository extends JpaRepository<DailyFact, UUID> {
+
+    Optional<DailyFact> findByFactDate(LocalDate factDate);
+
+    boolean existsByFactDate(LocalDate factDate);
+}

--- a/src/main/java/com/example/wellueducationservice/scheduler/DailyFactScheduler.java
+++ b/src/main/java/com/example/wellueducationservice/scheduler/DailyFactScheduler.java
@@ -1,0 +1,39 @@
+package com.example.wellueducationservice.scheduler;
+
+import com.example.wellueducationservice.exception.AiServiceException;
+import com.example.wellueducationservice.service.DailyFactService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+// scheduler/DailyFactScheduler.java
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyFactScheduler {
+
+    private final DailyFactService dailyFactService;
+
+    /**
+     * Fires every day at midnight (00:00:00) server time.
+     * zone = "UTC" keeps behaviour consistent across environments.
+     *
+     * For distributed deployments (multiple instances), couple this with
+     * ShedLock (@SchedulerLock) so only ONE pod executes per trigger.
+     */
+    @Scheduled(cron = "0 0 0 * * *", zone = "UTC")
+    public void scheduleDailyFactGeneration() {
+        log.info("Scheduler triggered: generating daily fact.");
+        try {
+            dailyFactService.generateDailyFact();
+            log.info("Scheduler: daily fact generation completed.");
+        } catch (AiServiceException ex) {
+            // Log and swallow — scheduler must not crash; alert monitoring instead
+            log.error("Scheduler: AI service unavailable. Fact generation failed. " +
+                    "Fallback will apply when first user requests today's fact.", ex);
+        } catch (Exception ex) {
+            log.error("Scheduler: unexpected error during fact generation.", ex);
+        }
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/service/DailyFactService.java
+++ b/src/main/java/com/example/wellueducationservice/service/DailyFactService.java
@@ -1,0 +1,88 @@
+package com.example.wellueducationservice.service;
+
+import com.example.wellueducationservice.client.AiServiceClient;
+import com.example.wellueducationservice.dto.response.AiFactResponse;
+import com.example.wellueducationservice.dto.response.DailyFactDto;
+import com.example.wellueducationservice.entity.DailyFact;
+import com.example.wellueducationservice.exception.AiServiceException;
+import com.example.wellueducationservice.exception.FactNotFoundException;
+import com.example.wellueducationservice.repository.DailyFactRepository;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+// service/DailyFactService.java
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DailyFactService {
+
+    private final DailyFactRepository repository;
+    private final AiServiceClient aiServiceClient;
+
+    /**
+     * Fetch today's fact. Returns from DB if available; otherwise generates a new one.
+     * Safe to call from multiple threads simultaneously.
+     */
+    @Transactional(readOnly = true)
+    public DailyFactDto getTodayFact() {
+        LocalDate today = LocalDate.now();
+        return repository.findByFactDate(today)
+                .map(DailyFactDto::from)
+                .orElseGet(() -> DailyFactDto.from(generateAndPersist(today)));
+    }
+
+    /**
+     * Called by the scheduler. Idempotent — skips generation if today's fact already exists.
+     */
+    public void generateDailyFact() {
+        LocalDate today = LocalDate.now();
+        if (repository.existsByFactDate(today)) {
+            log.info("Daily fact for {} already exists — skipping generation.", today);
+            return;
+        }
+        generateAndPersist(today);
+    }
+
+    /**
+     * Calls the AI service, persists the result, and returns it.
+     *
+     * Race-condition strategy:
+     *   Two threads can both pass the existsByFactDate check above before either writes.
+     *   The unique DB constraint ensures only ONE insert succeeds.
+     *   The losing thread catches DataIntegrityViolationException and re-reads the winner's row.
+     */
+    @Transactional
+    public DailyFact generateAndPersist(LocalDate date) {
+        try {
+            log.info("Calling AI service to generate fact for {}.", date);
+            AiFactResponse response = aiServiceClient.generateDailyFact();
+
+            DailyFact fact = new DailyFact();
+            fact.setContent(response.content());
+            fact.setCategory(response.category());
+            fact.setFactDate(date);
+            // createdAt and factDate filled by @PrePersist if not set
+
+            DailyFact saved = repository.save(fact);
+            log.info("Persisted daily fact [{}] for {}.", saved.getId(), date);
+            return saved;
+
+        } catch (DataIntegrityViolationException ex) {
+            // Another thread won the race — read what it inserted
+            log.warn("Race condition detected for {}; reading existing fact.", date);
+            return repository.findByFactDate(date)
+                    .orElseThrow(() -> new FactNotFoundException(
+                            "Expected fact for %s after constraint violation, but none found.".formatted(date)
+                    ));
+        } catch (FeignException ex) {
+            log.error("Feign exception calling AI service: {}", ex.getMessage(), ex);
+            throw new AiServiceException("Failed to reach AI Service", ex);
+        }
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/service/DailyFactService.java
+++ b/src/main/java/com/example/wellueducationservice/service/DailyFactService.java
@@ -29,7 +29,7 @@ public class DailyFactService {
      * Fetch today's fact. Returns from DB if available; otherwise generates a new one.
      * Safe to call from multiple threads simultaneously.
      */
-    @Transactional(readOnly = true)
+    @Transactional()
     public DailyFactDto getTodayFact() {
         LocalDate today = LocalDate.now();
         return repository.findByFactDate(today)
@@ -46,6 +46,7 @@ public class DailyFactService {
             log.info("Daily fact for {} already exists — skipping generation.", today);
             return;
         }
+        System.out.println("Generating");
         generateAndPersist(today);
     }
 
@@ -59,6 +60,7 @@ public class DailyFactService {
      */
     @Transactional
     public DailyFact generateAndPersist(LocalDate date) {
+        System.out.println("Starting the process");
         try {
             log.info("Calling AI service to generate fact for {}.", date);
             AiFactResponse response = aiServiceClient.generateDailyFact();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,36 @@
 spring.application.name=wellu-education-service
 server.port=8083
 
+# ========================
+# DATABASE
+# ========================
 spring.datasource.url=jdbc:postgresql://education-db:5432/education
 spring.datasource.username=education
 spring.datasource.password=password
 
+# Hikari (connection pool)
+spring.datasource.hikari.maximum-pool-size=10
+spring.datasource.hikari.minimum-idle=2
+
+# ========================
+# JPA / HIBERNATE
+# ========================
 spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.properties.hibernate.default_schema=public
+
+# ========================
+# FLYWAY
+# ========================
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+
+# ========================
+# AI SERVICE
+# ========================
+ai-service.base-url=http://127.0.0.1:8000
+
+# ========================
+# SCHEDULING
+# ========================
+scheduling.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,7 +28,7 @@ spring.flyway.locations=classpath:db/migration
 # ========================
 # AI SERVICE
 # ========================
-ai-service.base-url=http://127.0.0.1:8000
+ai-service.base-url=http://host.docker.internal:8000
 
 # ========================
 # SCHEDULING

--- a/src/main/resources/db/migration/V5__daily_facts.sql
+++ b/src/main/resources/db/migration/V5__daily_facts.sql
@@ -1,0 +1,10 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE daily_fact (
+                            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+                            content TEXT NOT NULL,
+                            category TEXT NOT NULL,
+
+                            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/main/resources/db/migration/V6__daily_fact_update.sql
+++ b/src/main/resources/db/migration/V6__daily_fact_update.sql
@@ -1,0 +1,19 @@
+-- 1. Change category type
+ALTER TABLE daily_fact
+ALTER COLUMN category TYPE VARCHAR(100);
+
+-- 2. Add fact_date  NOT NULL (no data to break)
+ALTER TABLE daily_fact
+    ADD COLUMN fact_date DATE NOT NULL;
+
+-- 3. Add unique constraint (one fact per day)
+ALTER TABLE daily_fact
+    ADD CONSTRAINT uq_daily_fact_date UNIQUE (fact_date);
+
+-- 4. Rename PK (optional, just for naming consistency)
+ALTER TABLE daily_fact
+    RENAME CONSTRAINT daily_fact_pkey TO pk_daily_fact;
+
+-- 5. Remove DEFAULT from created_at (since Java handles it now)
+ALTER TABLE daily_fact
+    ALTER COLUMN created_at DROP DEFAULT;


### PR DESCRIPTION
## 📚 Daily Fact Feature — Education Service

Closes #11 

---

### What does this PR do?

Implements the full Daily Fact feature end-to-end:

- Integrates with the external AI Service via Feign to generate educational facts
- Persists facts in PostgreSQL, enforcing **one fact per calendar day** at the DB level
- Pre-generates each day's fact at **midnight UTC** via a scheduled job
- Exposes `GET /api/v1/daily-facts/today` — returns the cached fact or generates one on-demand if the scheduler hasn't run yet

---

### Key Design Decisions

| Decision | Rationale |
|---|---|
| Unique constraint on `fact_date` | Enforced at DB level — bulletproof regardless of app-level bugs or concurrent instances |
| Race condition via catch + re-read | Two threads racing to insert → one wins, the other catches `DataIntegrityViolationException` and reads the winner's row. No distributed lock needed. |
| Feign `ErrorDecoder` | Maps HTTP 408/503/504 → `RetryableException` (auto-retried), others → `AiServiceException` (surfaces as HTTP 503 to client) |
| Scheduler swallows exceptions | Prevents Spring from silently killing the job on failure; user requests serve as a natural fallback |
| `readOnly = true` on `getTodayFact` | DB optimization hint — skips write transaction overhead on the happy path |




### How to Test Locally

1. Start PostgreSQL and the AI Service (`http://127.0.0.1:8000`)
2. Run the app: `mvn spring-boot:run`
3. Hit the endpoint:
```bash
curl http://localhost:8080/api/v1/daily-facts/today
```
4. Expected: HTTP 200 with fact JSON. Second call returns the same fact from DB (no AI call).

---
