### PR TITLE
feat: integrate OpenAPI Swagger with JWT authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+
         <!-- opencsv -->
         <dependency>
             <groupId>com.opencsv</groupId>

--- a/src/main/java/com/example/wellueducationservice/config/JwtConverterConfig.java
+++ b/src/main/java/com/example/wellueducationservice/config/JwtConverterConfig.java
@@ -1,6 +1,5 @@
 package com.example.wellueducationservice.config;
 
-import com.example.wellueducationservice.security.AuthenticatedUser;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -14,16 +13,10 @@ public class JwtConverterConfig {
     @Bean
     public JwtAuthenticationConverter jwtAuthenticationConverter() {
 
-        return userId -> {
-
-            AuthenticatedUser principal =
-                    new AuthenticatedUser(userId);
-
-            return new UsernamePasswordAuthenticationToken(
-                    principal,
-                    null,
-                    Collections.emptyList()
-            );
-        };
+        return userId -> new UsernamePasswordAuthenticationToken(
+                userId,
+                null,
+                Collections.emptyList()
+        );
     }
 }

--- a/src/main/java/com/example/wellueducationservice/config/OpenApiConfig.java
+++ b/src/main/java/com/example/wellueducationservice/config/OpenApiConfig.java
@@ -1,0 +1,38 @@
+package com.example.wellueducationservice.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Education Service API")
+                        .version("1.0")
+                        .description("Education Service APIs"))
+                .components(new Components()
+                        .addSecuritySchemes(
+                                securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        ))
+                .addSecurityItem(
+                        new SecurityRequirement()
+                                .addList(securitySchemeName)
+                );
+    }
+}

--- a/src/main/java/com/example/wellueducationservice/config/SecurityConfig.java
+++ b/src/main/java/com/example/wellueducationservice/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -48,15 +47,24 @@ public class SecurityConfig {
 
         return http
                 .csrf(csrf -> csrf.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .formLogin(formLogin -> formLogin.disable())
 
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
 
                 .authorizeHttpRequests(auth -> auth
+
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/v3/api-docs.yaml"
+                        ).permitAll()
+
                         .anyRequest().authenticated()
                 )
-
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(
                                 new CustomAuthenticationEntryPoint(objectMapper)
@@ -69,8 +77,6 @@ public class SecurityConfig {
                         jwtAuthFilter,
                         UsernamePasswordAuthenticationFilter.class
                 )
-
-                .httpBasic(Customizer.withDefaults())
 
                 .build();
     }

--- a/src/main/java/com/example/wellueducationservice/controller/HealthCheckContoller.java
+++ b/src/main/java/com/example/wellueducationservice/controller/HealthCheckContoller.java
@@ -1,10 +1,11 @@
 package com.example.wellueducationservice.controller;
 
 
-import com.example.wellueducationservice.security.AuthenticatedUser;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @RestController
 public class HealthCheckContoller {
@@ -12,9 +13,9 @@ public class HealthCheckContoller {
     @GetMapping("/me")
     public String me(Authentication authentication) {
 
-        AuthenticatedUser user =
-                (AuthenticatedUser) authentication.getPrincipal();
+        UUID userId =
+                (UUID) authentication.getPrincipal();
 
-        return user.getUserId().toString();
+        return userId.toString();
     }
 }


### PR DESCRIPTION
## Summary

Adds OpenAPI/Swagger integration to the education-service with JWT authentication support and security configuration updates.

## Changes

* Added SpringDoc OpenAPI integration
* Added Swagger UI support
* Configured OpenAPI metadata
* Added JWT Bearer authentication scheme
* Added global security requirements for Swagger
* Allowed Swagger endpoints in Spring Security
* Disabled HTTP Basic and Form Login for JWT-only authentication
* Added JWT authentication converter configuration
* Fixed authentication principal consistency by storing UUID as the authenticated principal

## Testing

* Verified Swagger UI loads successfully
* Verified `/v3/api-docs` endpoint works
* Verified JWT authentication works in Swagger
* Verified protected endpoints continue working in Postman
* Verified application starts successfully with Docker Compose

## Notes

This keeps the service stateless and preserves the existing JWT-based authentication flow while improving API documentation and developer experience.


closes #19